### PR TITLE
limiter: speed up infinity limiter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ futures-executor = "0.3.1"
 futures-util = { version = "0.3.1", default-features = false, features = ["std", "channel", "io", "io-compat"] }
 rand = "0.7.2"
 tokio = { version = "0.1.22", default-features = false, features = ["io", "rt-full", "codec"] }
+criterion = "0.3"
+
+[[bench]]
+name = "standard_clock"
+harness = false

--- a/benches/standard_clock.rs
+++ b/benches/standard_clock.rs
@@ -1,0 +1,18 @@
+// Copyright 2019 TiKV Project Authors. Licensed under MIT or Apache-2.0.
+
+use async_speed_limit::Limiter;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+// Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
+// infinity speed          time:   [32.527 ns 32.667 ns 32.818 ns]
+//                         change: [-0.2189% +0.3899% +1.0013%] (p = 0.20 > 0.05)
+fn criterion_benchmark_infinity_speed(c: &mut Criterion) {
+    let limiter = <Limiter>::new(f64::INFINITY);
+
+    c.bench_function("infinity speed", |b| {
+        b.iter(|| futures_executor::block_on(limiter.consume(1)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark_infinity_speed);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,6 @@ Asynchronously speed-limiting multiple byte streams (`AsyncRead` and `AsyncWrite
 See README for details.
 "
 )]
-#![cfg_attr(test, feature(test))]
-#![cfg(test)]
-extern crate test;
 
 pub mod clock;
 #[cfg(feature = "futures-io")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ Asynchronously speed-limiting multiple byte streams (`AsyncRead` and `AsyncWrite
 See README for details.
 "
 )]
+#![cfg_attr(test, feature(test))]
+#![cfg(test)]
+extern crate test;
 
 pub mod clock;
 #[cfg(feature = "futures-io")]

--- a/src/limiter.rs
+++ b/src/limiter.rs
@@ -391,11 +391,11 @@ impl<C: Clock, R: Unpin> Future for Consume<C, R> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let future = match this.future {
-            Some(ref mut future) => future,
-            None => return Poll::Ready(this.result.take().unwrap()),
+        let is_ready = match &mut this.future {
+            Some(future) => Pin::new(future).poll(cx).is_ready(),
+            None => true,
         };
-        if Pin::new(future).poll(cx).is_ready() {
+        if is_ready {
             if let Some(value) = this.result.take() {
                 return Poll::Ready(value);
             }

--- a/src/limiter.rs
+++ b/src/limiter.rs
@@ -1116,12 +1116,4 @@ mod tests_with_standard_clock {
             }
         }
     }
-
-    // Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
-    // test limiter::tests_with_standard_clock::bench_infinity_speed ... bench:          34 ns/iter (+/- 1)
-    #[bench]
-    fn bench_infinity_speed(b: &mut test::Bencher) {
-        let limiter = <Limiter>::new(f64::INFINITY);
-        b.iter(|| futures_executor::block_on(limiter.consume(1)));
-    }
 }


### PR DESCRIPTION
Speed up infinity limiter by skipping all mutex and allocation.

Benchmark shows a reasonable performance improvement.

```
# Master branch
test limiter::tests_with_standard_clock::bench_infinity_speed ... bench:       9,937 ns/iter (+/- 1,135)
# This PR
test limiter::tests_with_standard_clock::bench_infinity_speed ... bench:          34 ns/iter (+/- 1)
```
