### PR TITLE
Allow to activate tokio through a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ futures-timer = { version = "3.0.2", optional = true }
 futures-io = { version = "0.3.1", optional = true }
 futures-core = { version = "0.3.1", optional = true }
 pin-project-lite = "0.2.0"
-tokio = { version = "1", optional = true }
+tokio = { version = "1", features = ["io-util", "rt", "macros"], optional = true }
 
 [features]
 default = ["futures-io", "fused-future", "standard-clock"]
 standard-clock = ["futures-timer"]
 fused-future = ["futures-core"]
 read-initializer = ["futures-io/unstable", "futures-io/read-initializer"]
+tokio = ["dep:tokio"]
 
 [dev-dependencies]
 futures-executor = "0.3.1"


### PR DESCRIPTION
Hi tikv developers team!

I would like to be able to enable tokio like that:

```toml
async-speed-limit = { version = "0.4.0", features = ["default", "tokio"]}
```

That is not possible for now, as far as I understand, even if there already is an implementation.

Thanks for your awesome job! :pray: 