### PR TITLE
*: remove read-initializer feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-speed-limit"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The TiKV Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -13,7 +13,7 @@ all-features = true
 
 [dependencies]
 futures-timer = { version = "3.0.2", optional = true }
-futures-io = { version = "0.3.1", optional = true }
+futures-io = { version = "0.3.19", optional = true }
 futures-core = { version = "0.3.1", optional = true }
 pin-project-lite = "0.2.0"
 tokio = { version = "1", optional = true }
@@ -22,7 +22,7 @@ tokio = { version = "1", optional = true }
 default = ["futures-io", "fused-future", "standard-clock"]
 standard-clock = ["futures-timer"]
 fused-future = ["futures-core"]
-read-initializer = ["futures-io/unstable", "futures-io/read-initializer"]
+read-initializer = [] # This feature has been deprecated. It is only kept for downstream compatibility.
 
 [dev-dependencies]
 futures-executor = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the types.
 | **standard-clock** (default) | [futures-timer] | Enables the `clock::StandardClock` struct.                                                |
 | **fused-future** (default)   | [futures-core]  | Implements `FusedFuture` on `limiter::Consume`.                                           |
 | **futures-io** (default)     | [futures-io]    | Implements `AsyncRead` and `AsyncWrite` on `limiter::Resource`.                           |
-| **read-initializer**         | [futures-io]    | Implements `AsyncRead::initializer`.<br>Unstable and requires nightly compiler to enable. |
+| ~~**read-initializer**~~     | -               | Deprecated and does nothing. This feature has been removed since `futures-io 0.3.19`.     |
 
 [futures-core]: https://crates.io/crates/futures-core
 [futures-io]: https://crates.io/crates/futures-io

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,12 +12,6 @@ fn length_of_result_usize<B>(a: &io::Result<usize>, _: &B) -> usize {
 }
 
 impl<R: futures_io::AsyncRead, C: Clock> futures_io::AsyncRead for Resource<R, C> {
-    #[cfg(feature = "read-initializer")]
-    #[allow(unsafe_code)]
-    unsafe fn initializer(&self) -> io::Initializer {
-        self.get_ref().initializer()
-    }
-
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
     clippy::pedantic
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
-#![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 #![doc = include_str!("../README.md")]
 
 pub mod clock;


### PR DESCRIPTION
The `read-initializer` interface has been redesigned in Rust std. Therefore the feature has been removed since `futures-io 0.3.19`, so we are also removing it.